### PR TITLE
Move relp connection setup code from RelpServer::accept to new method.

### DIFF
--- a/lib/logstash/inputs/relp.rb
+++ b/lib/logstash/inputs/relp.rb
@@ -81,7 +81,7 @@ class LogStash::Inputs::Relp < LogStash::Inputs::Base
             #Will this catch everything I want it to?
             #Relp spec says to close connection on error, ensure this is the case
           ensure
-            socket.close
+            socket.close rescue nil
           end
         end # Thread.start
       rescue Relp::InvalidCommand,Relp::InappropriateCommand => e

--- a/lib/logstash/util/relp.rb
+++ b/lib/logstash/util/relp.rb
@@ -76,7 +76,9 @@ class Relp#This isn't much use on its own, but gives RelpServer and RelpClient t
         frame['message'] = socket.read(frame['datalen'])
       end
       @logger.debug? and @logger.debug("Read frame", :frame => frame)
-    rescue EOFError,Errno::ECONNRESET,IOError
+    rescue Errno::ECONNRESET
+      raise ConnectionClosed
+    rescue EOFError,IOError
       raise FrameReadException
     end
     if ! self.valid_command?(frame['command'])#TODO: is this enough to catch framing errors?


### PR DESCRIPTION
RelpServer::accept should return as soon as a TCP connection is accepted.
That connection will then be in its own thread and won't block other
connections being made.

Also added a new RelpError exception type.