### PR TITLE
Elapsed is using Socket without requiring it

### DIFF
--- a/lib/logstash/filters/elapsed.rb
+++ b/lib/logstash/filters/elapsed.rb
@@ -6,6 +6,7 @@
 require "logstash/filters/base"
 require "logstash/namespace"
 require 'thread'
+require 'socket'
 
 
 # The elapsed filter tracks a pair of start/end events and uses their


### PR DESCRIPTION
...causing errors if it's not used elsewhere as well.